### PR TITLE
Propagate `WriteAll` errors

### DIFF
--- a/atomicfile.go
+++ b/atomicfile.go
@@ -70,9 +70,9 @@ func WriteData(target string, data []byte, mode os.FileMode) error {
 // WriteAll copies all the data from r to the specified target path via a
 // [File].  It reports the total number of bytes copied.
 func WriteAll(target string, r io.Reader, mode os.FileMode) (nw int64, err error) {
-	Tx(target, mode, func(w io.Writer) error {
+	err = Tx(target, mode, func(w io.Writer) error {
 		nw, err = w.(*File).tmp.ReadFrom(r)
-		return nil
+		return err
 	})
 	return
 }

--- a/atomicfile_test.go
+++ b/atomicfile_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/iotest"
 
 	"github.com/creachadair/atomicfile"
 	"github.com/creachadair/mds/mtest"
@@ -16,6 +17,10 @@ import (
 var (
 	_ io.ReaderFrom = (*atomicfile.File)(nil)
 )
+
+type readerFunc func([]byte) (int, error)
+
+func (f readerFunc) Read(buf []byte) (int, error) { return f(buf) }
 
 func checkFile(t *testing.T, path string, perm os.FileMode, want string) {
 	t.Helper()
@@ -246,5 +251,51 @@ func TestWrite(t *testing.T) {
 			t.Errorf("Unexpected error: %v", err)
 		}
 		checkFile(t, path, 0664, input)
+	})
+}
+
+func TestWriteAllErrors(t *testing.T) {
+	t.Run("Read", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "target.txt")
+		const old = "existing target"
+		if err := os.WriteFile(path, []byte(old), 0640); err != nil {
+			t.Fatalf("Writing target file: %v", err)
+		}
+
+		testErr := errors.New("read failed")
+		const partial = "partial"
+		data := io.MultiReader(strings.NewReader(partial), iotest.ErrReader(testErr))
+		nw, err := atomicfile.WriteAll(path, data, 0600)
+		if err != testErr {
+			t.Errorf("Got error %v, want %v", err, testErr)
+		}
+		if nw != int64(len(partial)) {
+			t.Errorf("Length: got %d, want %d", nw, len(partial))
+		}
+		checkFile(t, path, 0640, old)
+	})
+
+	t.Run("Rename", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "target.txt")
+		const input = "new target"
+		data := readerFunc(func(buf []byte) (int, error) {
+			if err := os.Mkdir(path, 0700); err != nil {
+				return 0, err
+			}
+			return copy(buf, input), io.EOF
+		})
+
+		nw, err := atomicfile.WriteAll(path, data, 0600)
+		if err == nil {
+			t.Error("WriteAll should have reported an error")
+		}
+		if nw != int64(len(input)) {
+			t.Errorf("Length: got %d, want %d", nw, len(input))
+		}
+		if fi, err := os.Stat(path); err != nil {
+			t.Errorf("Stat target: %v", err)
+		} else if !fi.IsDir() {
+			t.Errorf("Target mode: got %v, want directory", fi.Mode())
+		}
 	})
 }


### PR DESCRIPTION
Makes `WriteAll` abort its transaction when reading the input fails, and return errors reported while closing or renaming the staged file.

I found this while investigating a corrupted entry served by our remote Go build cache in CI, which uses https://github.com/tailscale/go-cache-plugin. The S3 objects I sampled were intact, so I traced possible corruption paths through the plugin’s runner-local staging layer. An object body can return some bytes and then fail mid-stream, for example when a connection is interrupted.

`WriteAll` saved that read error in its named return value, but its transaction callback always returned `nil`. As a result, `Tx` treated the write as successful and renamed the partial temporary file over the target. The caller received the read error, but the incomplete target had already been published and could be reused by a later cache lookup.

`WriteAll` also discarded the return value from `Tx`. A successful read followed by a close or rename failure was therefore reported as successful.

Returning the read error from the callback preserves the existing transaction semantics: failed copies are cancelled instead of committed. Retaining the result from `Tx` also reports finalization failures to the caller.

The test cases here were added failing (TDD style) and pass with the fix.